### PR TITLE
[Draft] Add workflow for weekly deploy

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -1,0 +1,176 @@
+name: Weekly Build
+
+on:
+  schedule: # for scheduling to work this file must be in the default branch
+  - cron: "0 0 * * 3" # repeat every Wednesday
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  prepare-env:
+    runs-on: ubuntu-latest
+    outputs:
+      repos: ${{ steps.get-repo-names.outputs.repos }}
+      willitHash: ${{ steps.get-image-hash.outputs.willitHash }}
+
+    steps:
+    - name: Create containerfile
+      run: |
+        mkdir -p ./image
+        cat <<EOF>> ./image/willit.Containerfile
+        FROM quay.io/centos/centos:stream9
+        # EPEL
+        RUN dnf -y install 'dnf-command(config-manager)' && \
+            dnf -y config-manager --set-enabled crb && \
+            dnf -y install epel-release epel-next-release
+
+        # Project Dependencies
+        RUN dnf -y install \
+                python3-dnf \
+                python3-requests \
+                python3-bugzilla \
+                python3-jinja2 \
+                koji \
+                util-linux
+        EOF
+    
+    - name: Get image Hash
+      id: get-image-hash
+      run: |
+        echo "willitHash=${{ hashFiles('./image/willit.Containerfile') }}" >> "$GITHUB_OUTPUT"
+
+    - name: Get image from cache
+      id: image-cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          ./image/willit-deploy.tar
+        key: container-${{ hashFiles('./image/willit.Containerfile') }}
+
+    - uses: gacts/install-podman@v1
+      if: steps.image-cache.outputs.cache-hit != 'true'
+
+    - name: Build Image
+      if: steps.image-cache.outputs.cache-hit != 'true'
+      run: |
+        podman build -t willit-image:tmp -f ./image/willit.Containerfile .
+        podman save -o ./image/willit-deploy.tar willit-image:tmp
+
+    - uses: actions/checkout@v4
+      with:
+        path: willit
+
+    - name: Get repo names
+      id: get-repo-names
+      run: |
+        echo "repos=$( \
+            jq -c \
+              '[.repos[].RepoName | select( contains("-next") == false )]' \
+              willit/willit-config.json \
+          )" >> "$GITHUB_OUTPUT"
+
+  gen-repo-pages:
+    runs-on: ubuntu-latest
+    needs: prepare-env
+    strategy:
+      fail-fast: false
+      matrix:
+        repo: ${{ fromJson(needs.prepare-env.outputs.repos) }}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Filter config file
+      run: |
+        cat <<< $( \
+            jq '{ repos:[.repos[] | select( .RepoName | contains("${{ matrix.repo }}") ) ]}' \
+            willit-config.json \
+          ) > willit-config.json
+
+    - name: Get image from cache
+      id: image-cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          ./image/willit-deploy.tar
+        key: container-${{ needs.prepare-env.outputs.willitHash }}
+
+    - uses: gacts/install-podman@v1
+    - name: Load image
+      run: |
+        podman load < ./image/willit-deploy.tar
+    - name: Run process
+      run: |
+        podman run --rm \
+          -v $(pwd):/opt/willit \
+          -w /opt/willit \
+          willit-image:tmp python3 willit.py
+
+    - name: Upload output
+      uses: actions/upload-artifact@v4
+      with:
+        name: output-${{ matrix.repo }}
+        path: ./output/*
+        retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: gen-repo-pages
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Download repos output
+      uses: actions/download-artifact@v4
+      with:
+        path: .
+    
+    - name: Preprare merge environment
+      run: |
+        mkdir output
+        # Get all specific repo webpages
+        cp -r $(find . -mindepth 2 -maxdepth 2 -type d -iwholename "./output-*") output/
+        # Merge all status-overall.json files into one
+        jq \
+          -s add \
+          $( \
+            echo $( \
+              find . \
+                -mindepth 2 -maxdepth 2 \
+                -type f \
+                -iwholename "./output-*/status-overall.json" \
+            ) \
+          ) > output/status-overall.json
+
+        echo '{ "repos": [] }' > willit-config.json
+
+    - name: Get image from cache
+      id: image-cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          ./image/willit-deploy.tar
+        key: container-${{ needs.prepare-env.outputs.willitHash }}
+
+    - uses: gacts/install-podman@v1
+    - name: Load image
+      run: |
+        podman load < ./image/willit-deploy.tar
+    - name: Run merge process
+      run: |
+        podman run --rm \
+          -v $(pwd):/opt/willit \
+          -w /opt/willit \
+          willit-image:tmp python3 willit.py
+
+    - name: Upload output
+      uses: actions/upload-artifact@v4
+      with:
+        name: willit-output
+        path: ./output/*
+        retention-days: 1

--- a/willit.py
+++ b/willit.py
@@ -601,9 +601,14 @@ for this_repo in input_config['repos']:
 ## Overall Section
 Path("output").mkdir(parents=True, exist_ok=True)
 
-# Write out Overall json file
-with open('output/status-overall.json', 'w') as file:
-    json.dump(mainList, file)
+if len(input_config['repos']) > 0:
+  # Write out Overall json file
+  with open('output/status-overall.json', 'w') as file:
+      json.dump(mainList, file)
+else:
+  # Load old status-overall.json data as base
+  with open('output/status-overall.json', 'r') as file:
+      mainList = json.load(file)
 
 # Write out Overall Status Page
 with open('templates/status-overall.html.jira') as f:


### PR DESCRIPTION
This PR adds a Github Action workflow to run the willit scripts and generate their artifacts automatically.

Some modifications were required for this to work because GA jobs fail if they run for longer than 6 hours. To fix this, I made the process to run each EPEL repository separately and then merged the results. EPEL-next branches had to run with their base counterparts because they depend on their results.

The patch on willit.py enables it to merge previous runs by loading the merged status-overall.json if there are no repositories to process in the configuration... it's hacky and I would change it to make it more explicit, but I would like your input about it.

The script is run on a podman container using a centos:stream9 image as a base.

---

I left this as a draft for now because there are a couple of things I wanted to ask before merging it:

## Triggering

First, the triggering of this workflow was left to run each week on Wednesday, by pushing a change to the main branch, or by manual triggering in the Action tab. Is this fine? should we increase it's preiodicity? should I remove the branch commit trigger? 

## Deployment

Currently, this just generates the results and leaves it as a downloadable asset that can be accessed by the repo owner from the asset menu during the day it was generated. There are some options for automatic deployment that could get implemented:

### Github Pages on the same repository

Easiest to deal with, you would need to push a gh-pages branch to the repository (either to a detached head, the initial commit, or some other commit). Then enable to use Github Pages in the repository configuration.

This expects for the gh-pages config to read the webpage files from the docs directory. It would also require to add this job to the workflow.


```yml
  update-website:
    runs-on: ubuntu-latest
    needs: merge

    steps:
    - uses: actions/checkout@v4
      with:
        ref: 'gh-pages'
        path: 'gh-pages'

    - name: Download output files
      uses: actions/download-artifact@v4
      with:
        name: willit-output
        path: 'willit-output'
    
    - name: Sync web changes
      run: |
        mv willit-output/status-overall.html willit-output/index.html
        mkdir -p gh-pages/docs/
        rsync -azhuv --delete-after willit-output/ gh-pages/docs/
        git -C gh-pages add .

    - name: Commit report
      run: |
        git config --global user.name 'Sync Pages'
        git config --global user.email 'sync-bot@users.noreply.github.com'
        git -C gh-pages commit -am "Sync pages"
        git -C gh-pages push
```

The main problem with this option is that since the page will be saved to the repo, cloning will also bring the page mod history...

### Github Pages on another repository

This is a bit harder to configure, but it is posible to create a new repository, configure it to host a github page, and then push the results from this workflow there. The main issue is that it requires you to add a [PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) to the repository, which can be tedious on the long run.

The job is the same as the above one, but it needs this extra options in the checkout step.

```yml
        repository: ‘${{ github.actor }}’/willit-result
        token: ${{ secrets.GH_PAT }}
```

It might also need `cpina/github-action-push-to-another-repository@main` action, but I haven't tested that yet.

### Push directly to a server

This is also an option, but it would require to give the credentials to github... rsync is there... so you can do it at your own risk.

### Do it Manually

Just download the resulting file and decompress it somewhere. I can still add an extra step so that the result gets saved as a release so that it's easier to get and it lasts longer than a day.

I think the action would need to be something like

```yml
  generate-release:
    runs-on: ubuntu-latest
    needs: merge

    steps:
    - name: Download output files
      uses: actions/download-artifact@v4
      with:
        name: willit-output
        path: 'willit-output'

    - name: Archive Zip
      uses: thedoctor0/zip-release@main
      with:
        type: 'zip'
        filename: willit-output.zip
        directory: willit-output
        path: '*'

    - name: 'Release ZIP'
      uses: softprops/action-gh-release@v1
      with:
          files: willit-output/willit-output.zip
```

but I would need to test it out